### PR TITLE
Feature/modify readme, github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build and push images to ECR
 on:
   push:
     branches:
-      - 'master'
+      - 'hogehoge' # Enter any branch name
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ npm run gen component
 npm run gen redux
 ```
 
+### Deployment to ECR
+You can choose from two methods
+
+- Github Actions
+- CircleCI
+
 ## Test policy
 ### Component
 Mainly use [testing-library/react](https://github.com/testing-library/react-testing-library), [react-hooks](https://github.com/testing-library/react-hooks-testing-library).


### PR DESCRIPTION
## Todo 

- Update README
- Modify Build job of Github Actions
  - because the github actions will be executed ( and failed ) automatically.
  - In case of Circle CI, you have to turn the setting ON( linking CircleCI to the project )