### PR TITLE
Migrate data fetching API ?

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,7 @@
         "prettier/prettier": "error",
         "@typescript-eslint/explicit-function-return-type": [0, { "allowExpressions": true }],
         "@typescript-eslint/explicit-member-accessibility": [2, { "accessibility": "no-public" }],
+        "@typescript-eslint/explicit-module-boundary-types": [0, { "allowTypedFunctionExpressions": false }],
         "react/prop-types": [0]
     },
     "settings": {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -28,7 +28,7 @@ class CustomApp extends App<CustomProps> {
          * Can't extended AppContext to include CustomProps Type,
          * tentatively ignore ctx.store type lint.
          */
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         await ctx.store.execSagaTask(ctx.isServer, (dispatch: Dispatch) => {
             dispatch(counterActions.increment(1));

--- a/pages/api/signin.ts
+++ b/pages/api/signin.ts
@@ -4,7 +4,6 @@ import { Token } from '~/modelTypes';
 import Cookies from 'universal-cookie';
 import Auth from '~/service/auth';
 
-/*eslint @typescript-eslint/camelcase: ["error", {properties: "never"}]*/
 const pseudoToken: Token = {
     access_token:
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkNoaWJhIEtvdGFybyIsImlhdCI6MTU3NTQ0MzI4MiwiZXhwIjoxNjA5NDI2Nzk5fQ.DHZMvPjPCWMMyqo4v5oRM6ho3Miv4XwAxOr7gJBLyvc',

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -17,7 +17,11 @@ const Nav: React.FC = () => {
         <nav>
             <ul className="Nav-list">
                 <li>Header</li>
-                <li>link 1</li>
+                <li>
+                    <Link href="/todo">
+                        <a>TODO</a>
+                    </Link>
+                </li>
                 <li>link 2</li>
                 {!hasAccountData && (
                     <li>


### PR DESCRIPTION
## TODO
- Fix eslint warn settings
- Add TODO page link for navigation

## What I didn't do after all
- Change `getInitialProps` to `getServerSideProps`
  - Why?: Custom `<App />` required API is `getInitialProps` even now, so this project has no needs to use `getserverSideProps`.
    - Next step: We'll try to use `getServerSideProps` for `/pages` ;)