### PR TITLE
[ts-jest] update lib, target version

### DIFF
--- a/jest.tsconfig.json
+++ b/jest.tsconfig.json
@@ -3,7 +3,7 @@
         "allowJs": true,
         "jsx": "react",
         "lib": [
-            "es2017",
+            "es2019",
             "dom"
         ],
         "module": "commonjs",
@@ -17,7 +17,7 @@
         "skipLibCheck": true,
         "sourceMap": false,
         "strict": true,
-        "target": "esnext",
+        "target": "es2019",
         "baseUrl": "./",
         "paths": {
             "~/*": ["src/*"],


### PR DESCRIPTION
## TODO
- Remove below warning.
  - https://github.com/kulshekhar/ts-jest/commit/e512bc04fb4a368a79cb002ebad3a49c6e2e63f5#diff-18fc617b44692bcaf4a54f79ae44bb45
    - If you do not match the target, a warning will appear
    - [Node-Target-Mapping](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping)

```
ts-jest[config] (WARN) There is a mismatch between your NodeJs version v12.16.1 and your TypeScript target esnext. 
This might lead to some unexpected errors when running tests with `ts-jest`.
To fix this, you can check https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping
```