### PR TITLE
Add: CSP policy control

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -7,6 +7,14 @@ import Document, {
     DocumentContext
 } from 'next/document';
 
+import crypto from 'crypto';
+
+const cspHashOf = (text: string) => {
+    const hash = crypto.createHash('sha256');
+    hash.update(text);
+    return `'sha256-${hash.digest('base64')}'`;
+};
+
 class CustomDocument extends Document {
     static async getInitialProps(ctx: DocumentContext) {
         const initialProps = await Document.getInitialProps(ctx);
@@ -14,6 +22,15 @@ class CustomDocument extends Document {
     }
 
     render() {
+        let csp = `default-src 'self'; script-src 'self' ${cspHashOf(
+            NextScript.getInlineScriptSource(this.props)
+        )}`;
+        if (process.env.NODE_ENV !== 'production') {
+            csp = `style-src 'self' 'unsafe-inline'; font-src 'self' data:; default-src 'self'; script-src 'unsafe-eval' 'self' ${cspHashOf(
+                NextScript.getInlineScriptSource(this.props)
+            )}`;
+        }
+
         return (
             <Html>
                 <Head>
@@ -22,6 +39,7 @@ class CustomDocument extends Document {
                         h1, h2, h3, h4, h5, h6 { margin: 0; padding: 0; }
                         ul { margin: 0; padding: 0; list-style: none; }
                     `}</style>
+                    <meta httpEquiv="Content-Security-Policy" content={csp} />
                 </Head>
                 <body>
                     <Main />

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,6 @@
 import Koa, { ParameterizedContext } from 'koa';
 import Router from '@koa/router';
-// import KoaHelmet from 'koa-helmet';
+import KoaHelmet from 'koa-helmet';
 import next from 'next';
 
 import Logger from 'bunyan';
@@ -68,12 +68,16 @@ app.prepare()
             await next();
         });
 
-        /** @MEMO
-         * Too strict KoaHelmet security policy
-         * (next.js development mode gets stuck),
-         * so I have removed the use of the module once.
+        /**
+         * @MEMO
+         * CSP (Content Security Policy) is false for Web Server,
+         * so CSP is controlled by next.js `_document.tsx`
          */
-        // server.use(KoaHelmet());
+        server.use(
+            KoaHelmet({
+                contentSecurityPolicy: false
+            })
+        );
         server.use(router.routes());
         server.listen(port, () => {
             logger.info(`> Ready on localhost:${port}`);


### PR DESCRIPTION
## Todo
- Apply strict CSP at `_document.tsx` ([ref: via this source](https://github.com/vercel/next.js/blob/canary/examples/with-strict-csp/pages/_document.js)
- Re:attach `Koa-Helmet`
  - Remove `CSP` option
  - The rules applied are:
    - `dnsPrefetchControl`
    - `expectCt`
    - `frameguard`
    - `hidePoweredBy`
    - `hsts`
    - `ieNoOpen`
    - `noSniff`
    - `permittedCrossDomainPolicies`
    - `referrerPolicy`
    - `xssFilter`

### Ask
Do you think you need to apply the Helmet options in the first place?

### Remarks
- #101 